### PR TITLE
feat: unify requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocaine"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Evgeny Safronov <division494@gmail.com>"]
 description = "Cocaine Framework Rust"
 keywords = ["Cocaine"]

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,6 +1,5 @@
 extern crate cocaine;
 extern crate futures;
-extern crate rmpv;
 #[macro_use]
 extern crate slog;
 extern crate slog_envlogger;

--- a/examples/locator.rs
+++ b/examples/locator.rs
@@ -1,7 +1,6 @@
 extern crate cocaine;
 extern crate futures;
 extern crate tokio_core;
-extern crate rmpv;
 
 use futures::{Future, Stream, future};
 use tokio_core::reactor::Core;

--- a/examples/service.rs
+++ b/examples/service.rs
@@ -18,7 +18,7 @@ use slog::{DrainExt, Logger};
 
 use rmpv::ValueRef;
 
-use cocaine::{Dispatch, Error, Service};
+use cocaine::{Dispatch, Error, Request, Service};
 use cocaine::protocol::{self, Flatten, Primitive};
 
 struct ReadDispatch {
@@ -54,7 +54,7 @@ fn main() {
     let service = Service::new("storage", &handle);
 
     let (tx, rx) = oneshot::channel();
-    let future = service.call(0, &vec!["collection", "key"], vec![], ReadDispatch { tx: tx })
+    let future = service.call(Request::new(0, &["collection", "key"]).unwrap(), ReadDispatch { tx: tx })
         .then(|_sender| Ok(()));
 
     drop(service); // Just for fun to check that all pending request are proceeded until complete.

--- a/examples/unicorn.rs
+++ b/examples/unicorn.rs
@@ -1,6 +1,5 @@
 extern crate cocaine;
 extern crate futures;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -14,7 +14,7 @@ use futures::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use tokio_core::reactor::Core;
 
-use Service;
+use {Request, Service};
 
 const DEFAULT_LOGGING_NAME: &str = "logging";
 
@@ -45,7 +45,7 @@ impl Inner {
 //                            drop(tx);
 //                            Ok(())
 //                        }).boxed()
-                        service.call_mute_raw(0, buf);
+                        service.call_mute(Request::from_buf(0, buf));
                         future::ok(())
                     }
                     Event::Close => future::err(())

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,71 @@
+use std::fmt::{self, Debug, Formatter};
+
+use serde::Serialize;
+use rmps;
+
+use hpack::RawHeader;
+
+#[derive(Clone)]
+pub struct Request {
+    ty: u64,
+    buf: Vec<u8>,
+    headers: Vec<RawHeader>,
+}
+
+impl Request {
+    #[inline]
+    pub fn new<S: Serialize>(ty: u64, args: &S) -> Result<Self, rmps::encode::Error> {
+        let buf = rmps::to_vec(args)?;
+        let request = Request::from_buf(ty, buf);
+
+        Ok(request)
+    }
+
+    #[inline]
+    pub fn ty(&self) -> u64 {
+        self.ty
+    }
+
+    #[inline]
+    pub fn data(&self) -> &[u8] {
+        &self.buf
+    }
+
+    #[inline]
+    pub fn headers(&self) -> &[RawHeader] {
+        &self.headers
+    }
+
+    pub fn add_header<H: Into<RawHeader>>(mut self, header: H) -> Self {
+        self.headers.push(header.into());
+        self
+    }
+
+    pub fn add_headers<H: IntoIterator<Item=RawHeader>>(mut self, headers: H) -> Self {
+        self.headers.extend(headers);
+        self
+    }
+
+    pub(crate) fn into_components(self) -> (Vec<u8>, Vec<RawHeader>) {
+        (self.buf, self.headers)
+    }
+
+    #[inline]
+    pub(crate) fn from_buf(ty: u64, buf: Vec<u8>) -> Self {
+        Self {
+            ty: ty,
+            buf: buf,
+            headers: Vec::new(),
+        }
+    }
+}
+
+impl Debug for Request {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
+        fmt.debug_struct("Request")
+            .field("ty", &self.ty)
+            .field("len", &self.buf.len())
+            .field("headers", &self.headers)
+            .finish()
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,6 +5,27 @@ use rmps;
 
 use hpack::RawHeader;
 
+/// A generic Cocaine request.
+///
+/// Encapsulates all required parameters to be able to perform a service call.
+///
+/// # Examples
+///
+/// ```
+/// use cocaine::Request;
+/// use cocaine::hpack::{Header, TraceId, SpanId};
+///
+/// let request = Request::new(0, &["event"]).unwrap()
+///     .add_headers(vec![TraceId(0).into_raw(), SpanId(42).into_raw()]);
+///
+/// assert_eq!(0, request.ty());
+/// ```
+///
+/// # Errors
+///
+/// A serialization error is returned when it's failed to serialize the given arguments into a
+/// vector. However, while a vector is grown automatically, it may only fail when there is no
+/// memory left for allocation.
 #[derive(Clone)]
 pub struct Request {
     ty: u64,
@@ -13,6 +34,8 @@ pub struct Request {
 }
 
 impl Request {
+    /// Constructs a new request object using the given message type and arguments, performing an
+    /// automatic serialization.
     #[inline]
     pub fn new<S: Serialize>(ty: u64, args: &S) -> Result<Self, rmps::encode::Error> {
         let buf = rmps::to_vec(args)?;
@@ -21,26 +44,31 @@ impl Request {
         Ok(request)
     }
 
+    /// Returns a request type.
     #[inline]
     pub fn ty(&self) -> u64 {
         self.ty
     }
 
+    /// Returns a serialized request arguments as a slice.
     #[inline]
     pub fn data(&self) -> &[u8] {
         &self.buf
     }
 
+    /// Returns a reference to the request headers.
     #[inline]
     pub fn headers(&self) -> &[RawHeader] {
         &self.headers
     }
 
+    /// Adds a header to the request.
     pub fn add_header<H: Into<RawHeader>>(mut self, header: H) -> Self {
         self.headers.push(header.into());
         self
     }
 
+    /// Adds an iterable headers object to the request.
     pub fn add_headers<H: IntoIterator<Item=RawHeader>>(mut self, headers: H) -> Self {
         self.headers.extend(headers);
         self

--- a/src/service/locator.rs
+++ b/src/service/locator.rs
@@ -4,7 +4,7 @@ use std::net::{IpAddr, SocketAddr};
 use futures::{Future, Stream};
 use futures::sync::mpsc;
 
-use {Error, Service};
+use {Error, Request, Service};
 use dispatch::{PrimitiveDispatch, StreamingDispatch};
 use protocol::Flatten;
 use resolve::ResolveInfo as OuterResolveInfo;
@@ -93,7 +93,7 @@ impl Locator {
     /// ```
     pub fn resolve(&self, name: &str) -> impl Future<Item = Info, Error = Error> {
         let (dispatch, future) = PrimitiveDispatch::pair();
-        self.service.call(Method::Resolve.into(), &[name], Vec::new(), dispatch);
+        self.service.call(Request::new(Method::Resolve.into(), &[name]).unwrap(), dispatch);
 
         future.map(|ResolveInfo{addrs, version, methods}| {
             let addrs = addrs.into_iter()
@@ -113,7 +113,7 @@ impl Locator {
     {
         let (tx, rx) = mpsc::unbounded();
         let dispatch = StreamingDispatch::new(tx);
-        self.service.call(Method::Routing.into(), &[uuid], Vec::new(), dispatch);
+        self.service.call(Request::new(Method::Routing.into(), &[uuid]).unwrap(), dispatch);
         rx.map_err(|()| Error::Canceled).then(Flatten::flatten)
     }
 }

--- a/src/service/tvm.rs
+++ b/src/service/tvm.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use futures::Future;
 
-use {Error, Service};
+use {Error, Request, Service};
 use dispatch::PrimitiveDispatch;
 
 /// A grant type.
@@ -64,7 +64,7 @@ impl Tvm {
 
         match *grant {
             Grant::ClientCredentials => {
-                self.service.call(method, &(id, secret, ty, args), Vec::new(), dispatch);
+                self.service.call(Request::new(method, &(id, secret, ty, args)).unwrap(), dispatch);
             }
         }
 

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -16,7 +16,7 @@ use net2::TcpStreamExt;
 use rmpv::ValueRef;
 use tokio_core::reactor::Core;
 
-use cocaine::{Dispatch, Error, FixedResolver, ServiceBuilder};
+use cocaine::{Dispatch, Error, FixedResolver, Request, ServiceBuilder};
 
 fn endpoint() -> SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0)
@@ -145,7 +145,7 @@ fn dispatch_receives_rst() {
 
     let (tx, rx) = oneshot::channel();
 
-    match core.run(service.call(0, &["node"], Vec::new(), MockDispatch { tx: tx })) {
+    match core.run(service.call(Request::new(0, &["node"]).unwrap(), MockDispatch { tx: tx })) {
         Ok(..) => {}
         Err(Error::Io(ref err)) if err.kind() == ErrorKind::BrokenPipe => {}
         Err(err) => panic!("expected I/O error, actual {:?}", err),


### PR DESCRIPTION
Added:
- Generic request object, which encapsulates serialization and headers attachment.

Changed:
- Service call now accepts a request object.
- Now all requests can be easily extended with headers.
- Changed debug output a bit.
- Wrappers no longer requires a lifetime parameter.
- Unicorn wrapper now can accept strings by reference instead of heap-allocated strings by value.
- Drop unnecessary externs from examples.

Removed:
- No longer raw call.