### PR TITLE
feat: use headers in unicorn methods

### DIFF
--- a/examples/unicorn.rs
+++ b/examples/unicorn.rs
@@ -19,13 +19,13 @@ fn main() {
     let mut core = Core::new().unwrap();
     let unicorn = Unicorn::new(Service::new("unicorn", &core.handle()));
 
-    let future = unicorn.children_subscribe("/darkvoice/resources".into()).and_then(|(tx, stream)| {
+    let future = unicorn.children_subscribe("/darkvoice/resources".into(), None).and_then(|(tx, stream)| {
         stream.take(1).for_each(|(version, nodes)| {
             println!("Version: {}, nodes: {:?}", version, nodes);
 
             let mut futures = Vec::with_capacity(5001);
             for node in nodes {
-                futures.push(unicorn.get::<Resource>(&format!("/darkvoice/resources/{}", node)));
+                futures.push(unicorn.get::<Resource,_>(&format!("/darkvoice/resources/{}", node), None));
             }
 
             futures::future::join_all(futures).and_then(|result| {

--- a/src/service/unicorn.rs
+++ b/src/service/unicorn.rs
@@ -99,7 +99,7 @@ impl Unicorn {
     /// let mut core = Core::new().unwrap();
     /// let unicorn = Unicorn::new(Service::new("unicorn", &core.handle()));
     ///
-    /// let future = unicorn.get("/cocaine/config");
+    /// let future = unicorn.get("/cocaine/config", None);
     ///
     /// let (value, version): (Option<String>, i64) = core.run(future).unwrap();
     /// ```


### PR DESCRIPTION
Optional headers for `unicorn::{get, children_subscribe}`