### PR TITLE
refactor: stabilize on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,6 @@
 //! [service]: struct.Service.html
 //! [dispatch]: trait.Dispatch.html
 
-#![feature(conservative_impl_trait)]
-
 #![warn(missing_debug_implementations, missing_docs)]
 
 #[macro_use]


### PR DESCRIPTION
Since Rust 1.26 `impl Trait` is stable, but we're currently building on nightly, so it's useless for now. Soon the framework will build on stable.